### PR TITLE
Use dinghy-http-proxy v2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codekitchen/dinghy-http-proxy:2.2.0
+FROM codekitchen/dinghy-http-proxy:2.5
 MAINTAINER Benjamin Porter <BenjaminPorter86@gmail.com>
 
 # Copy our new template


### PR DESCRIPTION
Hey Ben,

with dinghy-http-proxy v2.5.5 a problem was fixed which led to failing `docker-compose down` because the proxy was still connected to the docker-compose project and the network couldn't be removed.
See also: https://github.com/codekitchen/dinghy/issues/218#issuecomment-272935064, https://github.com/codekitchen/dinghy-http-proxy/commit/8fc048c288c2bf0076d6c4f3a53dd9a566656653, https://github.com/codekitchen/dinghy-http-proxy/issues/23

Therefore it would be great to use a current version of dinghy-http-proxy as dory-http-proxy base.

If you accept the PR, could you please publish a new image version on docker hub and update the image tag in dory (https://github.com/FreedomBen/dory/blob/master/lib/dory/proxy.rb#L12) afterwards.

Thanks in advance!

As a temporary solution I build the updated image myself and set it in the dory config file with dory.nginx_proxy.image.
