### PR TITLE
Add support for xip.io hostnames

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -50,7 +50,7 @@ upstream {{ .Host }} {
 }
 
 server {
-	server_name {{ .Host }};
+	server_name {{ .Host }} ~^{{ .Host }}\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
 	listen 80;
 	access_log /var/log/nginx/access.log vhost;
 


### PR DESCRIPTION
I've just tested this and it seems to work nicely.

The only thing to note is that the variable `{{ .Host }}` will contain dots (`.`) that should really be backslash escaped (`\.`) in the regex. However since `.` in regex can be any character, it still works as you'd expect.