### PR TITLE
Add support for ARM, upgrade dinghy-http-proxy, add Makefile

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+version=2.6.2
+platforms=linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM codekitchen/dinghy-http-proxy:2.6.2
+ARG version
+
+FROM tripox/dinghy-http-proxy:${version}
 LABEL image.authors="Benjamin Porter <BenjaminPorter86@gmail.com>" \
       image.authors="Mathias Larsen <tripox@tripox.dk>"
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+include .env
+
+default: help
+
+## help	:	Prints this help.
+.PHONY: help
+help :
+	@sed -n 's/^##//p' Makefile
+
+## builder	:	Create the builder.
+.PHONY: builder
+builder :
+	docker buildx create --name dory --use
+
+## build push	:	Build and push docker images.
+.PHONY: build push
+build push :
+	docker buildx build --build-arg version=${version} --platform ${platforms} -t docker.io/tripox/dory-http-proxy:${version} . --push
+	docker buildx build --build-arg version=${version} --platform ${platforms} -t docker.io/tripox/dory-http-proxy:latest . --push

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # dory-http-proxy
 
-dory-http-proxy is the default http proxy for [dory](https://github.com/FreedomBen/dory)
+Forked from dinghy-http-proxy for SSL support. Not pushed upstream since the solution here is temporary.
 
-## Building and pushing
+### Build and push images
 
-Login, build, and push:
+Create the builder:
 
 ```bash
-$ DHP_VER=2.6.2.1
-$ docker login docker.io
-$ docker build -t docker.io/freedomben/dory-http-proxy:${DHP_VER} -t docker.io/freedomben/dory-http-proxy:latest .
-$ docker push docker.io/freedomben/dory-http-proxy:${DHP_VER}
-$ docker push docker.io/freedomben/dory-http-proxy:latest
-$ git tag "v${DHP_VER}" && git push --tags
+make builder
+```
+
+Build and push images:
+
+```bash
+make build push
 ```


### PR DESCRIPTION
- [x] Tested on x86_64
- [ ] Tested on ARM
- [ ] Change tag from `docker.io/tripox` to `docker.io/freedomben`

[See this issue](https://github.com/FreedomBen/dory/issues/49)

@FreedomBen 